### PR TITLE
Component guards

### DIFF
--- a/proposals/pattern-matching.md
+++ b/proposals/pattern-matching.md
@@ -560,7 +560,7 @@ An example:
 ```kotlin
 data class Person(val name: String, val age: Int, val contacts: List<Person>)
 val p: Person = // ...
-when(p){
+when(p) {
     is Person(name where { "-" !in it.substringAfterLast(" ") }, age where {it >= 18}, _) -> // ...
     is Person(_, _, _ where {it.size >= 5}) -> // ...
 }
@@ -568,11 +568,11 @@ when(p){
 
 The biggest benefit of this is allowing custom match comparisons instead of just equality, including inequalities, regex, case-insensitive equality, etc. 
 It also allows for some matching on collections or other types that don't destructure well. 
-A user could define their guards in functions like `is Person(name where ::isLastNameNotHyphenated, _, _)` for more complex guards.
+A user could define their guards like `is Person(name where isLastNameNotHyphenated, _, _)` through named lambdas or function references, for more complex guards.
 
 A large drawback is the verbosity. Large classes with lots of guards quickly become very long.
-This could cleaned up some by using a better syntax, but extra sytax will always be added to compoment declarations.
-However, assuming normal guards are implemented, the guard would be just as verbose, 
+This could cleaned up some by using a different, shorter syntax, but extra sytax will still always be added to compoment declarations.
+However, assuming normal guards are implemented, a guard would be just as verbose, 
 it would just cover all checks at once rather than doing the check where the component is declared, which may reduce readability.
 Doing checks at the component declaration also allows for checks on non-assigned (`_`) components, as in the last case in the example.
 

--- a/proposals/pattern-matching.md
+++ b/proposals/pattern-matching.md
@@ -406,6 +406,8 @@ when(someMapEntry) {
 The syntactic construct presented in the example is rather arbitrary and
 suggestions on different ones are welcome.
 
+This version works well with [component guards](#component-guards), as any equality checking could be done in the guard instead of using syntax like `==x`.
+
 #### Not allowing matching existing identifiers at all <a name="no-match"></a>
 This would make
 ```kotlin
@@ -550,7 +552,7 @@ val result = when(download) {
 }
 ```
 
-#### Component Guards <a name="component_guards"></a>
+#### Component Guards <a name="component-guards"></a>
 
 Guards could be extended to allow guards on destructured components, instead of just the entire case.
 
@@ -568,7 +570,7 @@ The biggest benefit of this is allowing custom match comparisons instead of just
 It also allows for some matching on collections or other types that don't destructure well. 
 A user could define their guards in functions like `is Person(name where ::isLastNameNotHyphenated, _, _)` for more complex guards.
 
-A large drawback is the verbosity.
+A large drawback is the verbosity. Large classes with lots of guards quickly become very long.
 This could cleaned up some by using a better syntax, but extra sytax will always be added to compoment declarations.
 However, assuming normal guards are implemented, the guard would be just as verbose, 
 it would just cover all checks at once rather than doing the check where the component is declared, which may reduce readability.

--- a/proposals/pattern-matching.md
+++ b/proposals/pattern-matching.md
@@ -1,7 +1,8 @@
 # Pattern Matching
 
 * **Type**: Design proposal
-* **Author**: Nicolas D'Cotta  <!-- * **Contributors**: This could be you! -->
+* **Author**: Nicolas D'Cotta 
+* **Contributors**: Ryan Nett
 * **Status**: New
 <!-- * **Prototype**: A transpiler to vanilla Kotlin in the near future -->
 
@@ -548,6 +549,30 @@ val result = when(download) {
   is App, Movie -> "Not by $expected"
 }
 ```
+
+#### Component Guards <a name="component_guards"></a>
+
+Guards could be extended to allow guards on destructured components, instead of just the entire case.
+
+An example:
+```kotlin
+data class Person(val name: String, val age: Int, val contacts: List<Person>)
+val p: Person = // ...
+when(p){
+    is Person(name where { "-" !in it.substringAfterLast(" ") }, age where {it >= 18}, _) -> // ...
+    is Person(_, _, _ where {it.size >= 5}) -> // ...
+}
+```
+
+The biggest benefit of this is allowing custom match comparisons instead of just equality, including inequalities, regex, case-insensitive equality, etc. 
+It also allows for some matching on collections or other types that don't destructure well. 
+A user could define their guards in functions like `is Person(name where ::isLastNameNotHyphenated, _, _)` for more complex guards.
+
+A large drawback is the verbosity.
+This could cleaned up some by using a better syntax, but extra sytax will always be added to compoment declarations.
+However, assuming normal guards are implemented, the guard would be just as verbose, 
+it would just cover all checks at once rather than doing the check where the component is declared, which may reduce readability.
+Doing checks at the component declaration also allows for checks on non-assigned (`_`) components, as in the last case in the example.
 
 ## Implementation
 > Disclaimer: contributions are welcome as the author has no background on the specifics of the Kotlin compiler, and only some on JVM bytecode.


### PR DESCRIPTION
Adds a component guards proposal to the Guards section in Beyond the proposal.

This would allow guards on individual components, e.g. `is Person(name where { "-" !in it.substringAfterLast(" ") }, age where {it >= 18}, _) -> ...`.  While it is quite verbose, some of that could be mitigated with a better syntax.  It allows for custom match conditions (by default, you would be limited to just equality).  In particular, it would allow for easily matching based on inequalities, regex, case-insensitive equality, starts/ends with, and many other relatively simple comparisons.  It also allows for better matching for not easily destructurable types like collections.